### PR TITLE
Add binding to unmap NvBuSurface if it has been mapped

### DIFF
--- a/bindings/docstrings/pydocumentation.h
+++ b/bindings/docstrings/pydocumentation.h
@@ -1541,6 +1541,12 @@ namespace pydsdoc
             :arg gst_buffer: address of the Gstbuffer which contains `NvBufSurface`
             :arg batchID: batch_id of the frame to be processed. This indicates the frame's index within `NvBufSurface`)pyds";
 
+        constexpr const char* unmap_nvds_buf_surface=R"pyds(
+            Unmap the previously mapped buffer. Do nothing if buffer has not been mapped.
+
+            :arg gst_buffer: address of the GstBuffer which contains `NvBufSurface`
+            :arg batch_id: batch_id of the frame to be unmap. This indicates the frame's index within `NvBufSurface`)pyds";
+
         constexpr const char* nvds_acquire_meta_lock=R"pyds(
             Acquire the lock before updating metadata.
 

--- a/docs/PYTHON_API/Methods/methodsdoc.rst
+++ b/docs/PYTHON_API/Methods/methodsdoc.rst
@@ -23,6 +23,12 @@ get_nvds_buf_surface
 .. autofunction:: pyds.get_nvds_buf_surface
 
 ==============
+unmap_nvds_buf_surface
+==============
+
+.. autofunction:: pyds.unmap_nvds_buf_surface
+
+==============
 nvds_acquire_meta_lock
 ==============
 


### PR DESCRIPTION
Unmap is needed to prevent memory leaks. I.e. using `get_nvds_buf_surface` on Jetson Xavier NX causes memory leaks since it maps buffer to CPU but don't unmap it. See https://forums.developer.nvidia.com/t/memory-leak-on-xavier-nx/234438 for details.