### PR TITLE
Update deepstream_rt_src_add_del.py

### DIFF
--- a/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
+++ b/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
@@ -161,6 +161,7 @@ def stop_release_source(source_id):
         print(pad_name)
         #Retrieve sink pad to be released
         sinkpad = streammux.get_static_pad(pad_name)
+        sinkpad.send_event(Gst.Event.new_eos())
         #Send flush stop event to the sink pad, then release from the streammux
         sinkpad.send_event(Gst.Event.new_flush_stop(False))
         streammux.release_request_pad(sinkpad)
@@ -178,6 +179,7 @@ def stop_release_source(source_id):
         pad_name = "sink_%u" % source_id
         print(pad_name)
         sinkpad = streammux.get_static_pad(pad_name)
+        sinkpad.send_event(Gst.Event.new_eos())
         sinkpad.send_event(Gst.Event.new_flush_stop(False))
         streammux.release_request_pad(sinkpad)
         print("STATE CHANGE ASYNC\n")


### PR DESCRIPTION
Send event new_eos in order to not freeze pipeline after deleting source like in https://github.com/NVIDIA-AI-IOT/deepstream_reference_apps/blob/9d37d32f785d7922bd4e49c0c6b76fdb11ad035b/runtime_source_add_delete/deepstream_test_rt_src_add_del.c#L197