### PR TITLE
fix: memory leak in NvDsEventMsgMeta

### DIFF
--- a/bindings/src/bindschema.cpp
+++ b/bindings/src/bindschema.cpp
@@ -160,6 +160,8 @@ namespace pydeepstream {
                     g_free (srcData->extMsg);
                     srcData->extMsgSize = 0;
                 }
+                g_free(srcData);
+                srcMeta->user_meta_data = NULL;
             }
         }
     }


### PR DESCRIPTION
I realize that when send event through msg broker, the memory is increase by the time. I found the problem at pyds.alloc_nvds_event_msg_meta(user_event_meta). The problem is we don't free srcData in event_msg_meta_release_func. Hope this will help anyone meet the problem about memory leak when send event by nvmsgbroker plugin.