### PR TITLE
Implement "get_nvds_LayerInfo_buffer"

### DIFF
--- a/bindings/docstrings/functionsdoc.h
+++ b/bindings/docstrings/functionsdoc.h
@@ -21,6 +21,13 @@ namespace pydsdoc
 {
     namespace methodsDoc
 	{
+        constexpr const char* get_nvds_LayerInfo_buffer=R"pyds(
+            This function returns the buffer of an :class:`NvDsInferLayerInfo` in Numpy format with dtype numpy.byte and ndim=1.
+
+            :arg data: An object of type :class:`NvDsInferLayerInfo`
+            
+            :returns: NumPy array containing the buffer of an :class:`NvDsInferLayerInfo` object)pyds";
+        
         constexpr const char* get_segmentation_masks=R"pyds(
             This function returns the inferred masks in Numpy format in the height X width shape, these height and width are obtained from the :class:`NvDsInferSegmentationMeta`.
 

--- a/bindings/src/bindfunctions.cpp
+++ b/bindings/src/bindfunctions.cpp
@@ -774,6 +774,35 @@ namespace pydeepstream {
               },
               py::return_value_policy::reference);
 
+        m.def("get_nvds_LayerInfo_buffer",
+              [](void *data) {
+                  auto *info = (NvDsInferLayerInfo *) data;
+                  unsigned char element_size = 0;
+                  switch (info->dataType) {
+                    case FLOAT:
+                    element_size = 4;
+                    break;
+                    case HALF:
+                    element_size = 2;
+                    break;
+                    case INT32:
+                    element_size = 4;
+                    break;
+                    case INT8:
+                    element_size = 1;
+                    break;
+                    case INT64:
+                    element_size = 8;
+                    break;
+                  }
+                  auto dtype = py::dtype(py::format_descriptor<signed char>::format());
+                  return py::array(dtype, {(info->inferDims).numElements * element_size},
+                                   {sizeof(signed char)},
+                                   info->buffer);
+              },
+              "data"_a,
+              pydsdoc::methodsDoc::get_nvds_LayerInfo_buffer);
+
         m.def("get_segmentation_masks",
               [](void *data) {
                   auto *META = (NvDsInferSegmentationMeta *) data;

--- a/docs/PYTHON_API/Methods/methodsdoc.rst
+++ b/docs/PYTHON_API/Methods/methodsdoc.rst
@@ -23,6 +23,12 @@ gst_element_send_nvevent_interval_update
 .. autofunction:: pyds.gst_element_send_nvevent_interval_update
 
 ======================
+get_nvds_LayerInfo_buffer
+======================
+
+.. autofunction:: pyds.get_nvds_LayerInfo_buffer
+
+======================
 get_segmentation_masks
 ======================
 


### PR DESCRIPTION
Implemented the function "get_nvds_LayerInfo_buffer" to get the buffer of an NvDsInferLayerInfo object as a 1-dimensional numpy array of dtype numpy.bytes . This handle can then be further processed in python using numpy.ndarray.view and numpy.ndarray.reshape .