### PR TITLE
Fix: use <pybind11/pybind11.h> includes for pybind11 >=2.x

### DIFF
--- a/bindings/include/pyds.hpp
+++ b/bindings/include/pyds.hpp
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <optional>
-#include <pybind11.h>
+#include <pybind11/pybind11.h>
 #include "pybind11/pybind11.h"
 #include "pybind11/cast.h"
 #include "pybind11/pytypes.h"

--- a/bindings/include/utils.hpp
+++ b/bindings/include/utils.hpp
@@ -33,7 +33,7 @@
 #include <optional>
 #include <mutex>
 #include <pybind11/cast.h>
-#include <pybind11.h>
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 


### PR DESCRIPTION
This fixes build errors when compiling pyds with newer pybind11 versions.
Changed includes from <pybind11.h> to <pybind11/pybind11.h>.
Tested on Jetson (DeepStream 7.1) – build succeeded and pyds works with GStreamer 1.20.3.