### PR TITLE
Fix(deps): pin cuda-python to 12.6

### DIFF
--- a/apps/README
+++ b/apps/README
@@ -53,7 +53,7 @@ $ sudo apt install python3-gi python3-dev python3-gst-1.0 -y
 
 **NEW** cuda-python
 -----------
-$ pip3 install cuda-python
+$ pip3 install cuda-python==12.6
 
 --------------------------------------------------------------------------------
 Running the samples
@@ -66,7 +66,7 @@ This will create the following directory:
 <DeepStream ROOT>/sources/deepstream_python_apps
 Cuda python APIs are used to distinguish between iGPU and dGPU.
 Install cuda-python using:
-pip3 install cuda-python
+pip3 install cuda-python==12.6
 NOTE: is_aarch64.py is deprecated in favor of platform_info.py
 Follow README in each app's directory to run the app.
 


### PR DESCRIPTION
`cuda-python` package to version `12.6`.

### Reason for change

The latest version of `cuda-python` (13.0) has removed the `cuda.cudart` module, as noted in the official release notes.

> **Breaking changes**  
> * The trampoline modules cuda.{cuda,cudart,nvrtc} are now removed. Users should switch to use cuda.bindings.{driver,runtime,nvrtc} instead.

*Source: [CUDA Python 13.0.0 Release Notes](https://nvidia.github.io/cuda-python/cuda-bindings/13.0.0/release/13.0.0-notes.html)*

Since some components in this repository may still depend on `cudart`, installing the latest version can cause runtime errors. Pinning the version to `12.6` ensures compatibility and prevents these issues.

```
python3 deepstream_test_1.py
Traceback (most recent call last):
  File "/opt/nvidia/deepstream/deepstream-7.1/sources/deepstream_python_apps/apps/deepstream-test1/deepstream_test_1.py", line 26, in <module>
    from common.platform_info import PlatformInfo
  File "/opt/nvidia/deepstream/deepstream-7.1/sources/deepstream_python_apps/apps/deepstream-test1/../common/platform_info.py", line 21, in <module>
    from cuda import cudart
ImportError: cannot import name 'cudart' from 'cuda' (unknown location)
```

This change updates the installation instructions in `apps/README`.

